### PR TITLE
Added auth parameter to send() and notify()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ Client.prototype._retrieveCallback = function (id) {
   return cb
 }
 
-Client.prototype.send = function (method, params) {
+Client.prototype.send = function (method, params, auth) {
   var self = this
 
   if (typeof method !== 'string') { throw new TypeError('Method must be a string') }
@@ -31,6 +31,8 @@ Client.prototype.send = function (method, params) {
 
   var req = { jsonrpc: '2.0', method: method, params: params }
 
+  if (auth) req.auth = auth; // as per jsonrpc auth extension
+  
   var callback = new Promise(function (resolve, reject) {
     req.id = self._registerCallback({ resolve: resolve, reject: reject })
   })
@@ -40,7 +42,7 @@ Client.prototype.send = function (method, params) {
     .then(function () { return callback })
 }
 
-Client.prototype.notify = function (method, params) {
+Client.prototype.notify = function (method, params, auth) {
   var self = this
 
   if (typeof method !== 'string') { throw new TypeError('Method must be a string') }
@@ -48,6 +50,8 @@ Client.prototype.notify = function (method, params) {
 
   var req = { jsonrpc: '2.0', method: method, params: params }
 
+  if (auth) req.auth = auth; // as per jsonrpc auth extension
+  
   return Promise.resolve()
     .then(function () { return self._sendMessage(req) })
 }


### PR DESCRIPTION
This allows to send a token for authentication. This could also be done using headers, but this is simpler. There was a JSONRPC auth extension with this spec but it no longer seems to be supported.